### PR TITLE
Fix the TypeScript type for the JSON file

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,5 +4,5 @@ import lcidJson = require('./lcid.json');
 
 expectType<number>(lcid.to('nb_NO'));
 expectType<string>(lcid.from(1044));
-expectType<{readonly [key: string]: number}>(lcid.all);
-expectType<{readonly [key: string]: number}>(lcidJson);
+expectType<{readonly [key: string]: string}>(lcid.all);
+expectType<{readonly [key: string]: string}>(lcidJson);

--- a/lcid.json.d.ts
+++ b/lcid.json.d.ts
@@ -1,3 +1,3 @@
-declare const lcidCodes: {readonly [localeId: string]: number};
+declare const lcidCodes: {readonly [localeId: string]: string};
 
 export = lcidCodes;


### PR DESCRIPTION
The return type for the lcid.json file was set to a number.
It should be set to a string as that is the correct return type i.e. 3081 => "en_AU"