### PR TITLE
fix: return types should include undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare const lcid: {
 	//=> 'nb_NO'
 	```
 	*/
-	from(lcidCode: number): string;
+  from(lcidCode: number): string | undefined;
 
 	/**
 	Get a [Windows locale identifier (LCID)](https://en.wikipedia.org/wiki/Locale#Specifics_for_Microsoft_platforms) from a [standard locale identifier](https://en.wikipedia.org/wiki/Locale_(computer_software)).
@@ -25,7 +25,7 @@ declare const lcid: {
 	//=> 1044
 	```
 	*/
-	to(localeId: string): number;
+  to(localeId: string): number | undefined;
 
 	/**
 	Mapping between [standard locale identifiers](https://en.wikipedia.org/wiki/Locale_(computer_software)) and [Windows locale identifiers (LCID)](https://en.wikipedia.org/wiki/Locale#Specifics_for_Microsoft_platforms).

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare const lcid: {
 	//=> 'nb_NO'
 	```
 	*/
-  from(lcidCode: number): string | undefined;
+	from(lcidCode: number): string | undefined;
 
 	/**
 	Get a [Windows locale identifier (LCID)](https://en.wikipedia.org/wiki/Locale#Specifics_for_Microsoft_platforms) from a [standard locale identifier](https://en.wikipedia.org/wiki/Locale_(computer_software)).
@@ -25,7 +25,7 @@ declare const lcid: {
 	//=> 1044
 	```
 	*/
-  to(localeId: string): number | undefined;
+	to(localeId: string): number | undefined;
 
 	/**
 	Mapping between [standard locale identifiers](https://en.wikipedia.org/wiki/Locale_(computer_software)) and [Windows locale identifiers (LCID)](https://en.wikipedia.org/wiki/Locale#Specifics_for_Microsoft_platforms).

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,7 +2,7 @@ import {expectType} from 'tsd';
 import lcid = require('.');
 import lcidJson = require('./lcid.json');
 
-expectType<number>(lcid.to('nb_NO'));
-expectType<string>(lcid.from(1044));
+expectType<number | undefined>(lcid.to('nb_NO'));
+expectType<string | undefined>(lcid.from(1044));
 expectType<{readonly [key: string]: string}>(lcid.all);
 expectType<{readonly [key: string]: string}>(lcidJson);


### PR DESCRIPTION
When calling `from` or `to`, the methods can return `undefined` but the types were not indicating that.

All tests pass.

This is the first time I am contributing to an open source package. I probably forgot a few things. Just let me know and I will happily comply. :)

Fixes #14